### PR TITLE
Fix path computation, import, and tag-mutation bugs in the loader

### DIFF
--- a/src/fastapi_file_router/router.py
+++ b/src/fastapi_file_router/router.py
@@ -1,12 +1,11 @@
-import importlib
+import importlib.util
 import logging
-import operator
 import os
 import re
-from collections.abc import Generator
+import sys
 from pathlib import Path
 from time import time
-from typing import Optional
+from types import ModuleType
 
 from fastapi import APIRouter, FastAPI
 
@@ -14,118 +13,123 @@ __all__ = ["load_routes"]
 
 logger = logging.getLogger("fastapi-file-router")
 
+_PARAM_RE = re.compile(r"\[(.*?)\]")
+# Common typos for "route". Anything else is treated as a real path segment.
+_TYPO_NAMES = frozenset({"routes", "router", "routers"})
 
-def log(message: str, verbose: bool = False):
+
+def log(message: str, verbose: bool = False) -> None:
     if verbose:
-        logger.info(message)  # Simple print can be replaced with any logging mechanism
+        logger.info(message)
     else:
         logger.debug(message)
 
 
 def square_to_curly_brackets(path: str) -> str:
     """Convert square brackets in a path to curly brackets for route parameters."""
-    return path.replace("[", "{").replace("]", "}")
+    return _PARAM_RE.sub(lambda m: "{" + m.group(1) + "}", path)
 
 
-def walk(directory: Path) -> Generator[tuple[str, list[str], list[str]], None, None]:
-    """Walk through the directory yielding each folder's path and filenames."""
-    yield from os.walk(directory)
+def _import_module_from_path(file_path: Path) -> ModuleType:
+    resolved = file_path.resolve()
+    module_name = f"fastapi_file_router._loaded_{abs(hash(str(resolved))):x}"
+    spec = importlib.util.spec_from_file_location(module_name, resolved)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load module from {resolved}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _segments_for(rel_parts: tuple[str, ...]) -> list[str]:
+    """Compute URL segments for a route file from its parts relative to the routes dir."""
+    *dir_parts, file_part = rel_parts
+    stem = Path(file_part).stem
+    segments = [square_to_curly_brackets(p) for p in dir_parts]
+    if stem == "route":
+        return segments
+    if _PARAM_RE.search(stem):
+        segments.append(square_to_curly_brackets(stem))
+    else:
+        segments.append(stem)
+    return segments
+
+
+def _sort_key(url_path: str) -> tuple[tuple[int, str], ...]:
+    """Sort routes so static segments come before parameter segments at every depth."""
+    parts = url_path.split("/") if url_path else []
+    return tuple((1 if "{" in p else 0, p) for p in parts)
 
 
 def load_routes(
-    app: FastAPI, directory: Path, auto_tags: bool = True, verbose: bool = False
-):
-    """
-    Dynamically load FastAPI routes from a specified directory.
+    app: FastAPI,
+    directory: Path,
+    auto_tags: bool = True,
+    verbose: bool = False,
+) -> FastAPI:
+    """Mount every route file under ``directory`` onto ``app``.
 
     Args:
-        app: The FastAPI app instance to include routers into.
-        directory: The directory path where route files are located.
-            It should follow
-            a structure where each file represents a route module, and nested
-            directories are translated into URL path segments. Files named 'route.py'
-            are treated as index routes for their directory. Filenames other than
-            'route.py' are appended to the path as additional segments. Square brackets
-            in directory names are converted to curly brackets in route paths to denote
-            path parameters.
-        auto_tags: Automatically set tags for routes based on file paths.
-        verbose: Enable detailed logging.
+        app: The FastAPI app to mount routers onto.
+        directory: A ``pathlib.Path`` to the routes folder. May be relative or
+            absolute; nesting (e.g. ``Path("src/routes")``) is supported.
+        auto_tags: If True, append the computed URL path to each router's tags
+            so endpoints group by route in the ``/docs`` UI. The caller's
+            ``router.tags`` list is not mutated.
+        verbose: Log every mounted route at INFO level on the
+            ``fastapi-file-router`` logger.
 
-    Example:
-        Given a directory structure:
-            /api
-                /users
-                    route.py       # Translates to /users
-                    [user_id].py   # Translates to /users/{user_id}
-                /documents
-                    /[document_id]
-                        route.py   # Translates to /documents/{document_id}
+    File-to-URL mapping rules:
+        * ``route.py`` is the index of its directory.
+        * Any other ``.py`` file becomes a URL segment.
+        * ``[param]`` in a file or directory name becomes ``{param}``.
+        * Files/directories starting with ``__`` are skipped (and not descended
+          into).
+        * Files exactly named ``routes.py``, ``router.py``, or ``routers.py``
+          are skipped to guard against typos for ``route.py``.
 
-        The 'route.py' file should define an 'APIRouter' instance named 'router'.
-        This function will load each router and configure it within the FastAPI application.
+    Each route module must define a top-level ``router = APIRouter()``.
     """
     start = time()
+    directory = Path(directory)
     log(f"Loading routes from {directory}", verbose)
 
-    routers: list[tuple[str, APIRouter]] = []
+    routers: list[tuple[str, APIRouter, list[str]]] = []
 
-    for root, _, files in walk(directory):
-        root = Path(root)
-        if root.name.startswith("__"):
-            continue
-        for file in files:
-            file_path = Path(file)
-            if file_path.name.startswith("__") or file_path.suffix != ".py":
+    for root, dirnames, files in os.walk(directory):
+        dirnames[:] = sorted(d for d in dirnames if not d.startswith("__"))
+        root_path = Path(root)
+
+        for file in sorted(files):
+            if file.startswith("__") or not file.endswith(".py"):
                 continue
-            if "route" in file_path.stem and file_path.stem != "route":
+            file_path = root_path / file
+            stem = file_path.stem
+            if stem in _TYPO_NAMES:
                 log(
-                    f"Skipping possibly misspelled route file {file_path.stem} in {root}",
-                    verbose=verbose,
+                    f"Skipping possibly misspelled route file {file_path} "
+                    "(did you mean route.py?)",
+                    verbose,
                 )
                 continue
 
-            route = importlib.import_module(
-                (root / file).as_posix().replace("/", ".")[:-3]
-            )
-            router: Optional[APIRouter] = getattr(route, "router", None)
-            if not router:
-                log(
-                    f"Router {(root / file).absolute().as_posix()} does not contain a router",
-                    verbose=verbose,
-                )
+            module = _import_module_from_path(file_path)
+            router = getattr(module, "router", None)
+            if not isinstance(router, APIRouter):
+                log(f"Skipping {file_path}: no `router: APIRouter` defined", verbose)
                 continue
 
-            route_path = square_to_curly_brackets(
-                "/".join((root / file).as_posix().split("/")[1:-1]),
-            ).replace(directory.name, "")
+            rel_parts = file_path.relative_to(directory).parts
+            segments = _segments_for(rel_parts)
+            url_path = ("/" + "/".join(segments)) if segments else ""
 
-            if re.search(r"\[(.*?)\]", file_path.stem):
-                # This is a parameter route like [user_id].py
-                # Extract parameter name from between square brackets
-                match = re.search(r"\[(.*?)\]", file_path.stem)
-                if match:
-                    param_name = match.group(1)
-                    route_path += f"/{{{param_name}}}"
-            elif file_path.stem != "route":
-                # This is a regular file, not a parameter route and not route.py
-                # Just add the filename as a path segment
-                route_path += f"/{file_path.stem}"
+            extra_tags = [url_path or "/"] if auto_tags else []
+            routers.append((url_path, router, extra_tags))
 
-            # Register the router
-            # convert root path to prefix
-            if auto_tags:
-                router.tags += [f"{route_path.replace(directory.name, '')}"]
-            routers.append((route_path, router))
+    for url_path, router, extra_tags in sorted(routers, key=lambda r: _sort_key(r[0])):
+        log(f"Loaded router at {url_path or '/'}", verbose)
+        app.include_router(router, prefix=url_path, tags=extra_tags)
 
-    # sort alphabetically
-    for route_path, router in sorted(routers, key=operator.itemgetter(0)):
-        prefix = f"/{route_path}" if route_path else ""
-        log(f"Loaded router with path {prefix or '/'}", verbose=verbose)
-        app.include_router(
-            router,
-            prefix=prefix,
-            tags=router.tags,
-        )
-    log(f"Routes loaded in {time() - start:.2f}s", verbose=verbose)
-
+    log(f"Routes loaded in {time() - start:.2f}s", verbose)
     return app

--- a/tests/test_file_router.py
+++ b/tests/test_file_router.py
@@ -1,56 +1,27 @@
-import os
-import shutil
-import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
-import pytest
-from fastapi import APIRouter, FastAPI
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
-# Import the module to test
-from fastapi_file_router.router import load_routes, square_to_curly_brackets
-
-
-@pytest.fixture
-def app():
-    """Fixture to create a FastAPI app instance."""
-    app = FastAPI()
-    # Mock the include_router method
-    app.include_router = MagicMock()
-    return app
+from fastapi_file_router import load_routes
+from fastapi_file_router.router import square_to_curly_brackets
 
 
-@pytest.fixture
-def temp_directory():
-    """Fixture to create a temporary directory for test files."""
-    temp_dir = tempfile.mkdtemp()
-    api_dir = os.path.join(temp_dir, "api")
-    os.makedirs(api_dir)
-
-    yield Path(api_dir)
-
-    # Clean up after the test
-    shutil.rmtree(temp_dir)
+def _make_route(path: Path, body: str = "{'ok': True}") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n"
+        "@router.get('')\n"
+        f"def handler(): return {body}\n"
+    )
 
 
-def create_route_file(directory, filename, with_router=True):
-    """Helper function to create test route files."""
-    os.makedirs(directory, exist_ok=True)
-    file_path = os.path.join(directory, filename)
-
-    with open(file_path, "w") as f:
-        f.write("from fastapi import APIRouter\n\n")
-        if with_router:
-            f.write("router = APIRouter(tags=[])\n\n")
-            f.write("@router.get('')\n")
-            f.write("def get_endpoint():\n")
-            f.write("    return {'message': 'success'}\n")
-        else:
-            f.write("# No router defined\n")
+def _mounted_paths(app: FastAPI) -> set[str]:
+    return {r.path for r in app.routes if hasattr(r, "path")}
 
 
 def test_square_to_curly_brackets():
-    """Test the square_to_curly_brackets function."""
     assert square_to_curly_brackets("users/[user_id]") == "users/{user_id}"
     assert (
         square_to_curly_brackets("products/[category]/[id]")
@@ -59,220 +30,236 @@ def test_square_to_curly_brackets():
     assert square_to_curly_brackets("normal/path") == "normal/path"
 
 
-def test_load_routes_basic(app, temp_directory):
-    """Test loading a simple route file."""
-    # Create a basic route.py file
-    users_dir = os.path.join(temp_directory, "users")
-    create_route_file(users_dir, "route.py")
-
-    # Setup the mock
-    with patch("fastapi_file_router.router.importlib.import_module") as mock_import:
-        # Configure the mock to return a module with a router
-        mock_module = MagicMock()
-        mock_router = APIRouter(tags=[])
-        mock_module.router = mock_router
-        mock_import.return_value = mock_module
-
-        # Call the function
-        load_routes(app, temp_directory, verbose=True)
-
-        # Use assert_called to check with less strict matching
-        assert app.include_router.called
-
-        # Check that the arguments match what we expect - get actual values from call
-        call_args = app.include_router.call_args
-        assert call_args[0][0] == mock_router
-
-        # Just verify the user path is included in the prefix, without worrying about the exact temp dir
-        assert "/users" in call_args[1]["prefix"]
-
-        # For the tag, just verify it contains the user path
-        assert any("/users" in tag for tag in call_args[1]["tags"])
+def test_basic_route(tmp_path: Path):
+    routes = tmp_path / "routes"
+    _make_route(routes / "users" / "route.py")
+    app = FastAPI()
+    load_routes(app, routes)
+    assert "/users" in _mounted_paths(app)
 
 
-def test_load_routes_parameter_file(app, temp_directory):
-    """Test loading a parameter route file like [user_id].py."""
-    # Create a parameter route file
-    users_dir = os.path.join(temp_directory, "users")
-    create_route_file(users_dir, "[user_id].py")
-
-    with patch("fastapi_file_router.router.importlib.import_module") as mock_import:
-        mock_module = MagicMock()
-        mock_router = APIRouter(tags=[])
-        mock_module.router = mock_router
-        mock_import.return_value = mock_module
-
-        load_routes(app, temp_directory, verbose=True)
-
-        # Check that the router was included
-        assert app.include_router.called
-
-        # Check that the arguments contain the parameter path
-        call_args = app.include_router.call_args
-        assert call_args[0][0] == mock_router
-
-        # Just verify the parameter path is included, without worrying about exact temp dir
-        assert "/users/{user_id}" in call_args[1]["prefix"]
-
-        # For the tag, verify it contains the parameter path
-        assert any("/users/{user_id}" in tag for tag in call_args[1]["tags"])
+def test_parameter_file(tmp_path: Path):
+    routes = tmp_path / "routes"
+    _make_route(routes / "users" / "[user_id].py")
+    app = FastAPI()
+    load_routes(app, routes)
+    assert "/users/{user_id}" in _mounted_paths(app)
 
 
-def test_load_routes_nested_structure(app, temp_directory):
-    """Test loading nested directory structure with various route types."""
-    # Create a more complex structure
-    users_dir = os.path.join(temp_directory, "users")
-    create_route_file(users_dir, "route.py")
-
-    user_id_dir = os.path.join(temp_directory, "users", "[user_id]")
-    create_route_file(user_id_dir, "route.py")
-    create_route_file(user_id_dir, "profile.py")
-
-    docs_dir = os.path.join(temp_directory, "documents")
-    create_route_file(docs_dir, "route.py")
-
-    with patch("fastapi_file_router.router.importlib.import_module") as mock_import:
-        # Set up the mock to return different routers for different imports
-        def side_effect(module_path):
-            mock_module = MagicMock()
-            mock_module.router = APIRouter(tags=[])
-            return mock_module
-
-        mock_import.side_effect = side_effect
-
-        load_routes(app, temp_directory, verbose=True)
-
-        # Check that app.include_router was called multiple times
-        assert app.include_router.call_count >= 4
+def test_parameter_directory(tmp_path: Path):
+    routes = tmp_path / "routes"
+    _make_route(routes / "products" / "[product_id]" / "route.py")
+    _make_route(routes / "products" / "[product_id]" / "reviews.py")
+    app = FastAPI()
+    load_routes(app, routes)
+    paths = _mounted_paths(app)
+    assert "/products/{product_id}" in paths
+    assert "/products/{product_id}/reviews" in paths
 
 
-def test_load_routes_skip_non_routers(app, temp_directory):
-    """Test that files without routers are skipped."""
-    users_dir = os.path.join(temp_directory, "users")
-    create_route_file(users_dir, "route.py", with_router=False)
-
-    with patch("fastapi_file_router.router.importlib.import_module") as mock_import:
-        # Mock the router module but don't add a router attribute
-        mock_module = MagicMock(spec=[])  # Empty spec - no router attribute
-        mock_import.return_value = mock_module
-
-        # Patch getattr to simulate attribute error when router is accessed
-        with patch("fastapi_file_router.router.getattr") as mock_getattr:
-            mock_getattr.return_value = None
-
-            load_routes(app, temp_directory, verbose=True)
-
-            # Since router is None, app.include_router should not be called with a router
-            for call in app.include_router.call_args_list:
-                # Verify none of the calls included our mock_module or None as router
-                assert call[0][0] is not None
-                assert call[0][0] is not mock_module
+def test_nested_structure(tmp_path: Path):
+    routes = tmp_path / "routes"
+    _make_route(routes / "users" / "route.py")
+    _make_route(routes / "users" / "profile.py")
+    _make_route(routes / "users" / "[user_id].py")
+    _make_route(routes / "documents" / "route.py")
+    app = FastAPI()
+    load_routes(app, routes)
+    assert {
+        "/users",
+        "/users/profile",
+        "/users/{user_id}",
+        "/documents",
+    }.issubset(_mounted_paths(app))
 
 
-def test_load_routes_skip_special_dirs_and_files(app, temp_directory):
-    """Test that __pycache__ directories and __init__.py files are skipped."""
-    # Create a __pycache__ directory
-    pycache_dir = os.path.join(temp_directory, "__pycache__")
-    os.makedirs(pycache_dir)
-    create_route_file(pycache_dir, "cached.py")
-
-    # Create a __init__.py file
-    init_file = os.path.join(temp_directory, "__init__.py")
-    with open(init_file, "w") as f:
-        f.write("# init file\n")
-
-    with patch("fastapi_file_router.router.importlib.import_module") as mock_import:
-        load_routes(app, temp_directory, verbose=True)
-
-        # Check that no imports were attempted for pycache
-        for call in mock_import.call_args_list:
-            assert "__pycache__" not in call[0][0]
-
-
-def test_load_routes_skip_misspelled_routes(app, temp_directory):
-    """Test that files with 'route' in the name but not exactly 'route.py' are skipped."""
-    users_dir = os.path.join(temp_directory, "users")
-    os.makedirs(users_dir, exist_ok=True)
-
-    # Create a misspelled route file
-    misspelled_file = os.path.join(users_dir, "router.py")
-    with open(misspelled_file, "w") as f:
-        f.write("# Misspelled route file\n")
-
-    initial_call_count = 0  # To track calls before our test
-
-    with patch("fastapi_file_router.router.importlib.import_module") as mock_import:
-        # This will make the import succeed but not find a router
-        mock_import.return_value = MagicMock(spec=[])
-
-        # We'll use this flag to detect if our specific file was processed
-        detected_router_py = False
-
-        # Override the original import_module to detect when our router.py is imported
-        original_import = mock_import.side_effect
-
-        def custom_import_side_effect(name):
-            nonlocal detected_router_py
-            if "router.py" in name:
-                detected_router_py = True
-            return MagicMock(spec=[])
-
-        mock_import.side_effect = custom_import_side_effect
-
-        load_routes(app, temp_directory, verbose=True)
-
-        # Our router.py file should not be imported since it's misspelled
-        assert not detected_router_py
+def test_static_segment_matches_before_param(tmp_path: Path):
+    """Regression: routes like /users/profile must be registered before /users/{user_id}."""
+    routes = tmp_path / "routes"
+    routes.mkdir(parents=True)
+    (routes / "users").mkdir()
+    (routes / "users" / "profile.py").write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n"
+        "@router.get('')\n"
+        "def f(): return {'kind': 'profile'}\n"
+    )
+    (routes / "users" / "[user_id].py").write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n"
+        "@router.get('')\n"
+        "def f(user_id: str): return {'kind': 'user', 'id': user_id}\n"
+    )
+    app = FastAPI()
+    load_routes(app, routes)
+    client = TestClient(app)
+    assert client.get("/users/profile").json() == {"kind": "profile"}
+    assert client.get("/users/123").json() == {"kind": "user", "id": "123"}
 
 
-def test_auto_tags_parameter(app, temp_directory):
-    """Test the auto_tags parameter."""
-    users_dir = os.path.join(temp_directory, "users")
-    create_route_file(users_dir, "route.py")
+def test_skip_misspelled_route_files(tmp_path: Path):
+    routes = tmp_path / "routes"
+    _make_route(routes / "users" / "route.py")
+    _make_route(routes / "users" / "router.py")
+    _make_route(routes / "users" / "routes.py")
+    app = FastAPI()
+    load_routes(app, routes)
+    paths = _mounted_paths(app)
+    assert "/users" in paths
+    assert "/users/router" not in paths
+    assert "/users/routes" not in paths
 
-    with patch("fastapi_file_router.router.importlib.import_module") as mock_import:
-        # With auto_tags=True
-        mock_module = MagicMock()
-        mock_router = APIRouter(tags=["existing_tag"])
-        mock_module.router = mock_router
-        mock_import.return_value = mock_module
 
-        load_routes(app, temp_directory, auto_tags=True, verbose=True)
+def test_allows_route_substring_in_filename(tmp_path: Path):
+    """Files like route_handler.py are legitimate; only exact typos are skipped."""
+    routes = tmp_path / "routes"
+    _make_route(routes / "route_handler.py")
+    _make_route(routes / "enroute.py")
+    app = FastAPI()
+    load_routes(app, routes)
+    paths = _mounted_paths(app)
+    assert "/route_handler" in paths
+    assert "/enroute" in paths
 
-        # Check that the arguments match
-        call_args = app.include_router.call_args
-        assert call_args[0][0] == mock_router
 
-        # Just verify the path contains users and the existing tag is present
-        assert "/users" in call_args[1]["prefix"]
-        assert "existing_tag" in call_args[1]["tags"]
+def test_skip_dunder_dirs_and_files(tmp_path: Path):
+    routes = tmp_path / "routes"
+    _make_route(routes / "users" / "route.py")
+    _make_route(routes / "__pycache__" / "fake.py")
+    _make_route(routes / "users" / "__pycache__" / "fake.py")
+    _make_route(routes / "users" / "__pycache__" / "nested" / "deep.py")
+    (routes / "__init__.py").write_text("# init\n")
+    app = FastAPI()
+    load_routes(app, routes)
+    paths = _mounted_paths(app)
+    assert "/users" in paths
+    assert not any("__pycache__" in p for p in paths)
+    assert not any("nested" in p or "deep" in p for p in paths)
 
-        # With auto_tags=False
-        app.include_router.reset_mock()
-        mock_router = APIRouter(tags=["existing_tag"])
-        mock_module.router = mock_router
-        mock_import.return_value = mock_module
 
-        load_routes(app, temp_directory, auto_tags=False, verbose=True)
+def test_skip_files_without_router(tmp_path: Path):
+    routes = tmp_path / "routes"
+    routes.mkdir(parents=True)
+    (routes / "lonely.py").write_text("# no router here\n")
+    (routes / "wrong_type.py").write_text("router = 'not a router'\n")
+    app = FastAPI()
+    load_routes(app, routes)
+    paths = _mounted_paths(app)
+    assert "/lonely" not in paths
+    assert "/wrong_type" not in paths
 
-        # Make sure only the original tags are present
-        call_args = app.include_router.call_args
-        assert call_args[0][0] == mock_router
-        assert "/users" in call_args[1]["prefix"]
-        assert call_args[1]["tags"] == ["existing_tag"]  # Only the original tag
+
+def test_auto_tags_appends_path(tmp_path: Path):
+    routes = tmp_path / "routes"
+    _make_route(routes / "users" / "route.py")
+    app = FastAPI()
+    load_routes(app, routes, auto_tags=True)
+    op = app.openapi()["paths"]["/users"]["get"]
+    assert "/users" in op["tags"]
+
+
+def test_auto_tags_false_preserves_user_tags(tmp_path: Path):
+    routes = tmp_path / "routes"
+    routes.mkdir(parents=True)
+    (routes / "users").mkdir()
+    (routes / "users" / "route.py").write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter(tags=['existing'])\n"
+        "@router.get('')\n"
+        "def f(): return {}\n"
+    )
+    app = FastAPI()
+    load_routes(app, routes, auto_tags=False)
+    tags = app.openapi()["paths"]["/users"]["get"]["tags"]
+    assert tags == ["existing"]
+
+
+def test_does_not_mutate_router_tags(tmp_path: Path):
+    """Regression: repeated load_routes calls must not accumulate tags on the router instance."""
+    routes = tmp_path / "routes"
+    routes.mkdir(parents=True)
+    (routes / "users").mkdir()
+    (routes / "users" / "route.py").write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter(tags=['original'])\n"
+        "@router.get('')\n"
+        "def f(): return {}\n"
+    )
+    for _ in range(3):
+        app = FastAPI()
+        load_routes(app, routes, auto_tags=True)
+    # Find the module loaded for this specific file and check its router's tags weren't appended to.
+    import sys
+
+    target_file = str((routes / "users" / "route.py").resolve())
+    loaded = [
+        m
+        for n, m in sys.modules.items()
+        if n.startswith("fastapi_file_router._loaded_")
+        and getattr(m, "__file__", None) == target_file
+    ]
+    assert loaded, "expected the loaded route module to be present in sys.modules"
+    for m in loaded:
+        assert m.router.tags == ["original"]
+
+
+def test_directory_basename_not_substring_stripped(tmp_path: Path):
+    """Regression: directory.name was string-replaced anywhere in the URL path."""
+    routes = tmp_path / "api"
+    _make_route(routes / "apicake" / "route.py")
+    _make_route(routes / "users" / "route.py")
+    app = FastAPI()
+    load_routes(app, routes)
+    paths = _mounted_paths(app)
+    assert "/apicake" in paths
+    assert "/cake" not in paths
+    assert "/users" in paths
+
+
+def test_nested_directory_path(tmp_path: Path):
+    """Regression: passing a multi-segment dir like Path('src/routes') used to make '//users'."""
+    routes = tmp_path / "src" / "routes"
+    _make_route(routes / "users" / "route.py")
+    app = FastAPI()
+    load_routes(app, routes)
+    paths = _mounted_paths(app)
+    assert "/users" in paths
+    assert "//users" not in paths
+
+
+def test_absolute_directory_path(tmp_path: Path):
+    """Regression: absolute paths broke the dotted-name importlib lookup."""
+    routes = tmp_path / "routes"
+    _make_route(routes / "users" / "route.py")
+    app = FastAPI()
+    load_routes(app, routes.resolve())
+    assert "/users" in _mounted_paths(app)
+
+
+def test_root_index_route(tmp_path: Path):
+    """A route.py at the routes root mounts at /."""
+    routes = tmp_path / "routes"
+    routes.mkdir(parents=True)
+    (routes / "route.py").write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n"
+        "@router.get('/')\n"
+        "def f(): return {'ok': True}\n"
+    )
+    app = FastAPI()
+    load_routes(app, routes)
+    assert TestClient(app).get("/").json() == {"ok": True}
 
 
 def test_log_function():
-    """Test the log function with proper mocking of the logger."""
+    from unittest.mock import patch
+
     with patch("fastapi_file_router.router.logger") as mock_logger:
-        # Import the log function after mocking the logger
         from fastapi_file_router.router import log
 
-        # Test verbose=True
-        log("Test message", verbose=True)
-        mock_logger.info.assert_called_once_with("Test message")
+        log("Info msg", verbose=True)
+        mock_logger.info.assert_called_once_with("Info msg")
 
-        # Test verbose=False
         mock_logger.reset_mock()
-        log("Debug message", verbose=False)
-        mock_logger.debug.assert_called_once_with("Debug message")
+        log("Debug msg", verbose=False)
+        mock_logger.debug.assert_called_once_with("Debug msg")


### PR DESCRIPTION
## Summary

The previous loader had several latent bugs that the test suite missed because every test mocked `app.include_router`. This PR replaces the mocks with real-file fixtures + a `TestClient`, then fixes each bug those new tests uncovered.

## Bugs fixed

| # | Severity | Bug |
|---|----------|-----|
| 1 | high | `directory.name` was stripped as a *substring* of the URL path. `Path("api")` + `api/apicake/route.py` → `/cake`. |
| 2 | high | Multi-segment directories like `Path("src/routes")` produced `//users` because only the leaf basename was stripped. |
| 3 | medium | `auto_tags` mutated the imported router's `.tags` list, so repeated `load_routes` calls accumulated duplicate tags. |
| 4 | medium | The "misspelled route file" guard rejected any filename containing the substring `route` — including legitimate names like `route_handler.py`. |
| 5 | medium | `importlib.import_module(...)` depended on the routes folder being reachable as a dotted name from `sys.path`; absolute paths silently failed. |
| 6 | low | `os.walk` was not pruned for `__`-prefixed directories, so files under `__pycache__/sub/` could still be processed. |
| 7 | low | Sorting alphabetically happened to put static segments before parameter ones only because `{` (0x7B) sorts after most letters; uncommon characters could shadow routes. |
| 8 | low | `if not router:` instead of `if router is None:` / `isinstance` check. |
| 9 | cosmetic | Redundant `.replace(directory.name, "")` on the auto-tag. |
| 10 | cosmetic | Pointless `walk()` wrapper around `os.walk`. |
| 11 | low | Mutated user-supplied `router.tags` list. |

## How

- Compute URL paths from `file_path.relative_to(directory).parts` — no more substring `.replace`.
- Load modules via `importlib.util.spec_from_file_location`, so absolute paths, nested directories, and re-loads all work.
- Build a fresh `tags` list per route and pass *only the auto-added tag* to `include_router`; the caller's `router.tags` is never mutated, and FastAPI handles router-level tags itself (so no duplication either).
- Narrow the typo guard to the literal filenames `routes.py`, `router.py`, `routers.py`.
- Prune `dirnames[:]` in `os.walk` so `__`-prefixed subtrees are not descended into.
- Sort with an explicit key that places static segments before parameterized segments at every depth.
- Replace the unit tests' `MagicMock(include_router)` setup with real route files written to `tmp_path`, asserting against `app.routes` and `TestClient` responses. Adds explicit regression tests for bugs 1–5.

## Test plan

- [x] `pytest tests -q` — 18 passing (was 9 passing against mocks).
- [x] `examples/` app runs end-to-end: every GET/POST/PUT in the example returns 200.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JsrKu6Bex6ZCkinW1Sx1GD)_

## Summary by Sourcery

Replace mocked router-loading tests with filesystem-based integration tests and fix multiple loader bugs discovered by them, including path computation, module importing, tag handling, and route filtering.

Bug Fixes:
- Fix URL path computation to derive segments from file paths relative to the routes directory, avoiding substring-based stripping and supporting nested directories and parameterized segments correctly.
- Fix module loading to work with absolute and nested route directories by importing from file paths rather than relying on dotted module names.
- Prevent mutation of user-supplied APIRouter.tags and avoid duplicated tags when auto_tags is enabled by computing per-route tags instead of appending to the router instance.
- Narrow the misspelled-route guard to skip only exact typo filenames like routes.py/router.py/routers.py while allowing legitimate filenames that merely contain the substring 'route'.
- Ensure __-prefixed directories and files are skipped during traversal so __pycache__ contents are not processed.
- Ensure static route segments are always registered before parameterized ones so paths like /users/profile are matched before /users/{user_id}.
- Avoid treating non-APIRouter router attributes as valid routers and skip such files with appropriate logging.

Enhancements:
- Introduce deterministic route sorting based on segment type to ensure consistent mounting order across depths.
- Refactor parameter placeholder handling to use a compiled regular expression for bracket-to-brace conversion.
- Return the FastAPI app instance from load_routes to support fluent usage and chaining.

Tests:
- Rewrite loader tests to create real route files under tmp_path and assert behavior via FastAPI routes and TestClient responses instead of mocking include_router and importlib.
- Add regression tests covering directory-name substring stripping, multi-segment route directories, absolute route directory paths, static-vs-parameter route precedence, tag behavior, typo file skipping, and dunder directory/file pruning.