### PR TITLE
Catch silent loader failures and tighten error reporting

### DIFF
--- a/src/fastapi_file_router/router.py
+++ b/src/fastapi_file_router/router.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from time import time
 from types import ModuleType
+from typing import Union
 
 from fastapi import APIRouter, FastAPI
 
@@ -38,7 +39,11 @@ def _import_module_from_path(file_path: Path) -> ModuleType:
         raise ImportError(f"Could not load module from {resolved}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        sys.modules.pop(module_name, None)
+        raise RuntimeError(f"Failed to load route file {file_path}: {exc}") from exc
     return module
 
 
@@ -64,7 +69,7 @@ def _sort_key(url_path: str) -> tuple[tuple[int, str], ...]:
 
 def load_routes(
     app: FastAPI,
-    directory: Path,
+    directory: Union[Path, str],
     auto_tags: bool = True,
     verbose: bool = False,
 ) -> FastAPI:
@@ -72,30 +77,44 @@ def load_routes(
 
     Args:
         app: The FastAPI app to mount routers onto.
-        directory: A ``pathlib.Path`` to the routes folder. May be relative or
-            absolute; nesting (e.g. ``Path("src/routes")``) is supported.
+        directory: Path to the routes folder. Accepts anything ``pathlib.Path``
+            accepts (``Path`` or ``str``). May be relative or absolute; nesting
+            (e.g. ``Path("src/routes")``) is supported.
         auto_tags: If True, append the computed URL path to each router's tags
             so endpoints group by route in the ``/docs`` UI. The caller's
-            ``router.tags`` list is not mutated.
+            ``router.tags`` list is not mutated; tags already present on the
+            router are not duplicated.
         verbose: Log every mounted route at INFO level on the
             ``fastapi-file-router`` logger.
 
     File-to-URL mapping rules:
         * ``route.py`` is the index of its directory.
         * Any other ``.py`` file becomes a URL segment.
-        * ``[param]`` in a file or directory name becomes ``{param}``.
+        * ``[param]`` in a file or directory name becomes ``{param}``. Mixed
+          names (e.g. ``[user_id]_admin.py``) keep the surrounding text and
+          mount at ``/{user_id}_admin``.
         * Files/directories starting with ``__`` are skipped (and not descended
           into).
         * Files exactly named ``routes.py``, ``router.py``, or ``routers.py``
           are skipped to guard against typos for ``route.py``.
 
-    Each route module must define a top-level ``router = APIRouter()``.
+    Each route module must define a top-level ``router = APIRouter()``. Modules
+    are imported via ``importlib.util.spec_from_file_location`` and their
+    top-level code re-executes on every call to ``load_routes`` — keep module
+    import side effects idempotent.
+
+    Raises:
+        FileNotFoundError: If ``directory`` is not an existing directory.
+        ValueError: If two route files resolve to the same URL path.
+        RuntimeError: If a route file raises during import.
     """
     start = time()
     directory = Path(directory)
+    if not directory.is_dir():
+        raise FileNotFoundError(f"Routes directory does not exist: {directory}")
     log(f"Loading routes from {directory}", verbose)
 
-    routers: list[tuple[str, APIRouter, list[str]]] = []
+    routers: list[tuple[str, Path, APIRouter, list[str]]] = []
 
     for root, dirnames, files in os.walk(directory):
         dirnames[:] = sorted(d for d in dirnames if not d.startswith("__"))
@@ -124,10 +143,26 @@ def load_routes(
             segments = _segments_for(rel_parts)
             url_path = ("/" + "/".join(segments)) if segments else ""
 
-            extra_tags = [url_path or "/"] if auto_tags else []
-            routers.append((url_path, router, extra_tags))
+            extra_tags: list[str] = []
+            if auto_tags:
+                tag = url_path or "/"
+                if tag not in router.tags:
+                    extra_tags.append(tag)
 
-    for url_path, router, extra_tags in sorted(routers, key=lambda r: _sort_key(r[0])):
+            routers.append((url_path, file_path, router, extra_tags))
+
+    seen: dict[str, Path] = {}
+    for url_path, file_path, _router, _tags in routers:
+        if url_path in seen:
+            raise ValueError(
+                f"Duplicate route path {url_path or '/'!r}: "
+                f"{seen[url_path]} and {file_path} both map to it"
+            )
+        seen[url_path] = file_path
+
+    for url_path, _file_path, router, extra_tags in sorted(
+        routers, key=lambda r: _sort_key(r[0])
+    ):
         log(f"Loaded router at {url_path or '/'}", verbose)
         app.include_router(router, prefix=url_path, tags=extra_tags)
 

--- a/tests/test_file_router.py
+++ b/tests/test_file_router.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -249,6 +250,58 @@ def test_root_index_route(tmp_path: Path):
     app = FastAPI()
     load_routes(app, routes)
     assert TestClient(app).get("/").json() == {"ok": True}
+
+
+def test_missing_directory_raises(tmp_path: Path):
+    app = FastAPI()
+    with pytest.raises(FileNotFoundError):
+        load_routes(app, tmp_path / "does-not-exist")
+
+
+def test_string_directory_argument(tmp_path: Path):
+    routes = tmp_path / "routes"
+    _make_route(routes / "users" / "route.py")
+    app = FastAPI()
+    load_routes(app, str(routes))
+    assert "/users" in _mounted_paths(app)
+
+
+def test_duplicate_url_paths_raise(tmp_path: Path):
+    """Regression: routes/users.py and routes/users/route.py both map to /users."""
+    routes = tmp_path / "routes"
+    _make_route(routes / "users.py")
+    _make_route(routes / "users" / "route.py")
+    app = FastAPI()
+    with pytest.raises(ValueError, match="Duplicate route path '/users'"):
+        load_routes(app, routes)
+
+
+def test_route_file_import_error_is_wrapped(tmp_path: Path):
+    routes = tmp_path / "routes"
+    routes.mkdir(parents=True)
+    bad = routes / "broken.py"
+    bad.write_text("raise RuntimeError('boom')\n")
+    app = FastAPI()
+    with pytest.raises(RuntimeError, match="Failed to load route file") as info:
+        load_routes(app, routes)
+    assert isinstance(info.value.__cause__, RuntimeError)
+    assert "boom" in str(info.value.__cause__)
+
+
+def test_auto_tags_does_not_duplicate_existing_tag(tmp_path: Path):
+    routes = tmp_path / "routes"
+    routes.mkdir(parents=True)
+    (routes / "users").mkdir()
+    (routes / "users" / "route.py").write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter(tags=['/users'])\n"
+        "@router.get('')\n"
+        "def f(): return {}\n"
+    )
+    app = FastAPI()
+    load_routes(app, routes, auto_tags=True)
+    tags = app.openapi()["paths"]["/users"]["get"]["tags"]
+    assert tags == ["/users"]
 
 
 def test_log_function():


### PR DESCRIPTION
## Summary

Follow-up to #7. The rescan turned up seven remaining issues; this PR fixes all of them.

| # | Severity | Fix |
|---|----------|-----|
| 1 | medium | `FileNotFoundError` when `directory` doesn't exist (was silent no-op). |
| 2 | medium | `ValueError` when two files compute the same URL (`users.py` + `users/route.py` was double-registering, shadowing the second). |
| 3 | low | Wrap exceptions during route-file import in `RuntimeError(f"Failed to load route file {path}: ...")` so the traceback points at the offending file. `sys.modules` is cleaned up on failure. |
| 4 | doc | Document that route modules re-execute on every `load_routes` call. |
| 5 | doc | Document that mixed names (`[user_id]_admin.py`) preserve the surrounding text. |
| 6 | cosmetic | Skip the auto-tag if it's already on the router, avoiding duplicates in `/docs`. |
| 7 | nit | Widen `directory` annotation to `Path \| str`; body already calls `Path(directory)`. |

## Test plan

- [x] `pytest tests -q` — 23 passing (18 previously + 5 new regression tests for each behavior change).
- [x] `examples/` app still serves every GET/POST/PUT with 200.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JsrKu6Bex6ZCkinW1Sx1GD)_

## Summary by Sourcery

Improve FastAPI file router error handling and route loading robustness.

Bug Fixes:
- Raise FileNotFoundError when the routes directory does not exist.
- Detect and reject duplicate route URL paths that map from multiple files.
- Wrap exceptions raised during route-module import in a RuntimeError that identifies the offending file and cleans up sys.modules.
- Avoid adding duplicate auto-generated tags to routers when auto_tags is enabled.

Enhancements:
- Allow load_routes to accept both Path and string directory arguments and document this behavior.
- Document module re-execution semantics and file-to-URL mapping nuances in the load_routes docstring.

Tests:
- Add regression tests covering missing directories, string directory arguments, duplicate URL paths, wrapped import errors, and non-duplicated auto tags.